### PR TITLE
docs: remove transformSource as it is deprecated in storybook 6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,6 @@ To add a component implementation to storybook, we use the `<component-name>-sto
 - Declare the possible inputs, with types and a description in the `argTypes` property of the `Meta` component in `stories.mdx`.
 - Add an `Argstable` component in your `stories.mdx`
 - Optionally add a different `status` to the `Meta` parameters. The options and colors can be found in `.storybook/preview.js`
-- Add the code below to the `Meta` parameters to ensure a resolved code example in your story, instead of the Template function:
-
-```javascript
-parameters: {
-    docs: {
-      transformSource: (_src, { args }) => Template(args),
-    },
-    // ...
-}
-```
 
 ---
 

--- a/components/button/bem.stories.mdx
+++ b/components/button/bem.stories.mdx
@@ -19,9 +19,6 @@ export const Template = ({ content }) =>
     },
   }}
   parameters={{
-    docs: {
-      transformSource: (_src, { args }) => Template(args),
-    },
     status: "IN DEVELOPMENT",
     notes: { UX: README },
   }}

--- a/components/button/stencil.stories.mdx
+++ b/components/button/stencil.stories.mdx
@@ -16,9 +16,6 @@ export const Template = ({ content }) => `<example-button>${content}</example-bu
     },
   }}
   parameters={{
-    docs: {
-      transformSource: (_src, { args }) => Template(args),
-    },
     status: {
       type: "WORK IN PROGRESS",
     },


### PR DESCRIPTION
Apparently the template didn't exclude minor storybook updates, so this repository already is updated to storybook 6.4. However we still had an issue where component examples didn't render correctly in this version.

By removing the deprecated `transformSource` all stories will run without issue 🥳