### PR TITLE
fix: realigning list and removing marker

### DIFF
--- a/documentation/demopages/nl-design-system/common/patches/_lists.scss
+++ b/documentation/demopages/nl-design-system/common/patches/_lists.scss
@@ -1,0 +1,3 @@
+.utrecht-unordered-list__item::marker {
+  content: var(--utrecht-unordered-list-item-marker);
+}

--- a/documentation/demopages/nl-design-system/common/style.scss
+++ b/documentation/demopages/nl-design-system/common/style.scss
@@ -8,3 +8,4 @@
 @use "patches/breadcrumbs";
 @use "patches/button-group";
 @use "patches/link";
+@use "patches/lists";

--- a/proprietary/design-tokens/src/components/utrecht/ordered-list.tokens.json
+++ b/proprietary/design-tokens/src/components/utrecht/ordered-list.tokens.json
@@ -14,7 +14,8 @@
         "color": {}
       },
       "padding-inline-start": {
-        "value": "40px"
+        "value": "40px",
+        "comment": "Explicitly setting the user agent default (40px)"
       }
     }
   }

--- a/proprietary/design-tokens/src/components/utrecht/unordered-list.tokens.json
+++ b/proprietary/design-tokens/src/components/utrecht/unordered-list.tokens.json
@@ -1,17 +1,29 @@
 {
   "utrecht": {
     "unordered-list": {
-      "margin-block-start": { "value": "0" },
-      "margin-block-end": { "value": "{rvo.space.md}" },
+      "margin-block-start": {
+        "value": "0"
+      },
+      "margin-block-end": {
+        "value": "{rvo.space.md}"
+      },
       "item": {
         "margin-block-start": {},
         "margin-block-end": {},
-        "padding-inline-start": { "value": "{rvo.space.2xs}" }
+        "padding-inline-start": {
+          "value": "0"
+        },
+        "marker": {
+          "value": "initial"
+        }
       },
       "marker": {
         "color": {}
       },
-      "padding-inline-start": { "value": "40px" }
+      "padding-inline-start": {
+        "value": "40px",
+        "comment": "Explicitly setting the user agent default (40px)"
+      }
     }
   }
 }


### PR DESCRIPTION
RVO doesn't use the marker. So we should set this to a token value. In this case 'initial'.