### PR TITLE
fix: table inline button styling

### DIFF
--- a/documentation/demopages/nl-design-system/common/rvo/_table.scss
+++ b/documentation/demopages/nl-design-system/common/rvo/_table.scss
@@ -1,0 +1,11 @@
+.rvo-table-cell {
+  &--link {
+    & form {
+      display: flex;
+      flex-wrap: wrap;
+    }
+    & button {
+      font-weight: 400;
+    }
+  }
+}

--- a/documentation/demopages/nl-design-system/common/style.scss
+++ b/documentation/demopages/nl-design-system/common/style.scss
@@ -2,6 +2,7 @@
 @use "rvo/progress_tracker";
 @use "rvo/form";
 @use "rvo/spacers";
+@use "rvo/table";
 
 /* Component patches
    Patch files will be removed when components have been updated and released */


### PR DESCRIPTION
Buttons shouldn't be bold and don't wrap. This is specific to the table. 

If space is sufficient, the buttons will sit on a single line.
Unclear if all buttons should have a normal (400) font-weight. If so, then this should be made generic and not implemented here.