### PR TITLE
feat: export React FooterMenu including CSS

### DIFF
--- a/packages/components-react/src/Footer.tsx
+++ b/packages/components-react/src/Footer.tsx
@@ -6,17 +6,17 @@ import { PageFooter } from '@utrecht/component-library-react';
 import { PropsWithChildren } from 'react';
 // import { MaxWidthLayout } from '../../max-width-layout/template';
 
-interface IFooterItem {
+export interface IFooterItem {
   content: string;
   link?: string;
 }
 
-interface IFooterColumn {
+export interface IFooterColumn {
   label?: string;
   items: IFooterItem[];
 }
 
-interface IFooterProps {
+export interface IFooterProps {
   columns: IFooterColumn[];
 }
 

--- a/packages/components-react/src/FooterMenu.tsx
+++ b/packages/components-react/src/FooterMenu.tsx
@@ -4,12 +4,12 @@
  */
 import { Heading, Link } from './index';
 
-interface IFooterMenuLinkProps {
+export interface IFooterMenuLinkProps {
   textContent: string;
   href?: string;
 }
 
-interface IFooterMenuProps {
+export interface IFooterMenuProps {
   links: IFooterMenuLinkProps[];
   heading?: string;
 }

--- a/packages/components-react/src/Icon.tsx
+++ b/packages/components-react/src/Icon.tsx
@@ -10,7 +10,7 @@ export type IconColor = 'hemelblauw' | 'wit' | 'zwart';
 
 export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
 
-interface IconProps extends UtrechtIconProps {
+export interface IconProps extends UtrechtIconProps {
   icon: string;
   size?: string | IconSize;
   color?: string | IconColor;

--- a/packages/components-react/src/Logo.tsx
+++ b/packages/components-react/src/Logo.tsx
@@ -5,7 +5,7 @@
 import clsx from 'clsx';
 import { ForwardedRef, forwardRef } from 'react';
 
-interface LogoProps {
+export interface LogoProps {
   title?: string;
   subtitle?: string;
   className?: string;

--- a/packages/components-react/src/css-module/FooterMenu.tsx
+++ b/packages/components-react/src/css-module/FooterMenu.tsx
@@ -1,0 +1,7 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Community for NL Design System
+ */
+import '../../../../components/footer/index.scss';
+
+export * from '../FooterMenu';

--- a/packages/components-react/src/css-module/index.ts
+++ b/packages/components-react/src/css-module/index.ts
@@ -5,6 +5,7 @@
 
 // Components by RVO
 export { Footer } from './Footer';
+export { FooterMenu } from './FooterMenu';
 export { Icon } from './Icon';
 export { Link } from './Link';
 export { Logo } from './Logo';


### PR DESCRIPTION
RIVM is starting to use these components too, they are missing some small things.