### PR TITLE
fix: remove trailing whitespace

### DIFF
--- a/documentation/pages/schrijfwijzer/woordenlijst-rvo.docusaurus.mdx
+++ b/documentation/pages/schrijfwijzer/woordenlijst-rvo.docusaurus.mdx
@@ -149,7 +149,7 @@ Afkorting: OESO-richtlijnen
 Gebruik in een tekst de eerste keer de naam voluit, daarna afgekort. Omdat de afkorting al in de naam staat, zet je bij de eerste keer voluit de afkorting niet achter de naam.
 
 Offshore-windsector  
-Officieel is de correcte spelling 'offshorewindsector' (aan elkaar), omdat offshore slaat op wind. Voor de leesbaarheid is het streepje toegestaan.  
+Officieel is de correcte spelling 'offshorewindsector' (aan elkaar), omdat offshore slaat op wind. Voor de leesbaarheid is het streepje toegestaan.
 
 Offshore windmolenpark  
 Met spatie, omdat offshore slaat op park.


### PR DESCRIPTION
Trailing spaces (2 or more) to indicate a break (`<br>`) are only allowed when followed by a line of text.