### PR TITLE
feat: don't trim trailing spaces in .md(x) files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ charset = UTF-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.{md,mdx}]
+# 2 or more spaces have meaning in Markdown so don't trim
+trim_trailing_whitespace = false


### PR DESCRIPTION
Prettier is set up and will still complain about trailing whitespace where there shouldn't be any.

This change makes sure that editors that honour `.editorconfig` do not trim trailing whitespace in Markdown and MDX files.