### PR TITLE
fix: add lerna.json#packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,7 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "npmClient": "pnpm",
   "version": "independent",
-  "useWorkspaces": true,
+  "npmClient": "pnpm",
   "command": {
     "publish": {},
     "version": {
@@ -12,5 +11,7 @@
       "exact": true,
       "message": "docs(release): design system packages\n\n[skip ci]"
     }
-  }
+  },
+  "packages": ["./documentation/", "./components", "./components/*", "./packages/", "./proprietary", "./uxpin-merge"],
+  "useWorkspaces": false
 }


### PR DESCRIPTION
Set lerna.json#useWorkspaces to false as the docs state this should only be used for npm and yarn workspaces.
Add lerna.json#packages because package.json#workspaces was removed in 457873e4035f37306a258db0fd7bc2cf61e1f610