### PR TITLE
Action group position issue due to class usage

### DIFF
--- a/.changeset/polite-flowers-allow.md
+++ b/.changeset/polite-flowers-allow.md
@@ -1,0 +1,5 @@
+---
+"@nl-rvo/css-action-group": patch
+---
+
+Removed rvo class `.rvo-button-group__align-right` causing position issues with the second button. Added parameter `position` allowing action groups to be placed left or right. Default this is the left position

--- a/components/action-group/src/defaultArgs.ts
+++ b/components/action-group/src/defaultArgs.ts
@@ -19,4 +19,5 @@ const defaultButtonsRight = [
 export const defaultArgs: IActionGroupProps = {
   buttonsLeft: defaultButtonsLeft,
   buttonsRight: defaultButtonsRight,
+  position: 'left',
 };

--- a/components/action-group/src/index.scss
+++ b/components/action-group/src/index.scss
@@ -8,6 +8,10 @@
   flex-wrap: wrap;
 }
 
+.rvo-action-groul--position-right {
+  justify-content: flex-end;
+}
+
 .rvo-action-group--align-right {
   margin-inline-start: auto;
 }

--- a/components/action-group/src/template.tsx
+++ b/components/action-group/src/template.tsx
@@ -16,6 +16,7 @@ export interface IActionGroupProps {
   /** @uxpinignoreprop */
   buttonsRight?: IButtonProps[];
   fullWidth?: boolean;
+  position?: 'left' | 'right';
   /** @uxpinpropname Buttons */
   children?: ReactNode | undefined;
   className?: string;
@@ -53,12 +54,14 @@ export const ActionGroup: React.FC<IActionGroupProps> = ({
   children,
   fullWidth = defaultArgs.fullWidth,
   className,
+  position = defaultArgs.position,
 }: IActionGroupProps) => {
   return (
     <ButtonGroup
       className={clsx(
         {
           'rvo-action-group--full-width': fullWidth,
+          'rvo-action-groul--position-right': position === 'right',
         },
         className,
       )}
@@ -68,10 +71,7 @@ export const ActionGroup: React.FC<IActionGroupProps> = ({
         buttonsLeft?.map((buttonProps, index) => {
           return <Button key={index} {...buttonProps} />;
         })}
-      {!children &&
-        buttonsRight?.map((buttonProps, index) => (
-          <Button key={index} {...buttonProps} className="rvo-action-group--align-right" />
-        ))}
+      {!children && buttonsRight?.map((buttonProps, index) => <Button key={index} {...buttonProps} />)}
     </ButtonGroup>
   );
 };


### PR DESCRIPTION
Removed rvo class `.rvo-button-group__align-right` causing position issues with the second button. Added parameter `position` allowing action groups to be placed left or right. Default this is the left position