### PR TITLE
Text underscore for all buttons when hovering

### DIFF
--- a/.changeset/wild-toys-applaud.md
+++ b/.changeset/wild-toys-applaud.md
@@ -1,0 +1,5 @@
+---
+"@nl-rvo/css-button": patch
+---
+
+Underline visible for all button types on hover

--- a/components/button/src/index.scss
+++ b/components/button/src/index.scss
@@ -7,13 +7,19 @@
 .utrecht-button {
   flex-shrink: 0;
   text-wrap: nowrap;
+
+  &--hover:not(:disabled),
+  &:hover:not(:disabled, [aria-disabled="true"], .utrecht-button--disabled) {
+    text-decoration: underline;
+    text-underline-offset: 30%;
+  }
 }
 
 // Subtle button
 .utrecht-button--subtle.utrecht-button--hover:not(:disabled),
 .utrecht-button--subtle.utrecht-button-link--hover:not(:disabled),
 .utrecht-button--subtle:hover:not(:disabled, [aria-disabled="true"], .utrecht-button--disabled) {
-  text-decoration: var(--utrecht-button-subtle-hover-text-decoration, underline);
+  text-decoration: var(--_utrecht-button-appearance-hover-color, underline);
   text-underline-offset: 30%;
 }
 


### PR DESCRIPTION
Small css change to button component where a text-decoration is added on hover.