### PR TITLE
Fix/tag prop type

### DIFF
--- a/.changeset/metal-timers-hear.md
+++ b/.changeset/metal-timers-hear.md
@@ -1,0 +1,6 @@
+---
+"@nl-rvo/css-tag": patch
+"@nl-rvo/component-library-react": patch
+---
+
+allow the content prop to contain react nodes instead of strings

--- a/components/tag/src/template.tsx
+++ b/components/tag/src/template.tsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 Community for NL Design System
  */
 import clsx from 'clsx';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { defaultArgs } from './defaultArgs';
 import { Icon, options as iconOptions } from '../../icon/src/template';
 import { IconType } from '../../icon/src/types';
@@ -11,7 +11,7 @@ import { StatusIcon } from '../../status-icon/src/template';
 import './index.scss';
 
 export interface ITagProps {
-  content: string;
+  content: ReactNode;
   type: 'default' | 'info' | 'bevestiging' | 'foutmelding' | 'waarschuwing';
   showIcon?: 'no' | 'before' | 'after';
   icon?: IconType;


### PR DESCRIPTION
The Tag component content prop should be more permissive since its content should also have the ability to render react nodes instead of just strings. This if fixed in this PR. 