### PR TITLE
ROOS-88: Pagination now has className prop and html atrributes props forwarded to the root element

### DIFF
--- a/.changeset/beige-numbers-dress.md
+++ b/.changeset/beige-numbers-dress.md
@@ -1,0 +1,6 @@
+---
+"@nl-rvo/css-pagination": patch
+"@nl-rvo/component-library-react": patch
+---
+
+pagination now has className prop and html atrributes props forwarded to the root element

--- a/components/pagination/src/template.tsx
+++ b/components/pagination/src/template.tsx
@@ -3,18 +3,16 @@
  * Copyright (c) 2021 Community for NL Design System
  */
 import clsx from 'clsx';
-import React, { ReactNode, useEffect, useMemo, useState } from 'react';
+import React, { HTMLAttributes, ReactNode, useEffect, useMemo, useState } from 'react';
 import { defaultArgs } from './defaultArgs';
 import Link from '../../link/src/template';
 import './index.scss';
 
-export interface IPaginationProps {
-  numberOfPages: number;
-  /**
-   * @uxpinbind onChange 0
-   */
+export interface IPaginationProps extends Omit<HTMLAttributes<HTMLElement>, 'onPageChange'> {
   activePage: number;
-  onChange?: (currentPage: number) => void;
+  className?: string;
+  numberOfPages: number;
+  onPageChange?: (currentPage: number) => void;
 }
 
 export const argTypes = {
@@ -24,7 +22,7 @@ export const argTypes = {
   activePage: {
     control: 'number',
   },
-  onChange: {
+  onPageChange: {
     table: {
       disable: true,
     },
@@ -34,34 +32,34 @@ export const argTypes = {
 const generatePageNumbers = (
   totalPages: number,
   activePage: number,
-  onChange?: IPaginationProps['onChange'],
+  onPageChange?: IPaginationProps['onPageChange'],
 ): ReactNode[] => {
   const pages: ReactNode[] = [];
 
   // Always add the first page
-  pages.push(generatePageNumber(1, activePage, onChange));
+  pages.push(generatePageNumber(1, activePage, onPageChange));
 
   // Add ellipses if the active page is more than 4
   if (activePage > 4) {
     pages.push(generateEllipses('ellipses-1'));
   }
   if (activePage === 4) {
-    pages.push(generatePageNumber(2, activePage, onChange));
+    pages.push(generatePageNumber(2, activePage, onPageChange));
   }
 
   // Add the page before the active page if it's more than 2
   if (activePage > 2) {
-    pages.push(generatePageNumber(activePage - 1, activePage, onChange));
+    pages.push(generatePageNumber(activePage - 1, activePage, onPageChange));
   }
 
   // Add the active page if it's not the first or last page
   if (activePage > 1 && activePage < totalPages) {
-    pages.push(generatePageNumber(activePage, activePage, onChange));
+    pages.push(generatePageNumber(activePage, activePage, onPageChange));
   }
 
   // Add the page after the active page if it's less than total pages minus 1 and not the last page
   if (activePage < totalPages - 1 && activePage !== totalPages - 2) {
-    pages.push(generatePageNumber(activePage + 1, activePage, onChange));
+    pages.push(generatePageNumber(activePage + 1, activePage, onPageChange));
   }
 
   // Add ellipses if the active page is less than the total pages minus 3
@@ -71,18 +69,18 @@ const generatePageNumbers = (
 
   // Add the second last page if the active page is less than the total pages minus 1 and greater than or equal to total pages minus 3
   if (activePage < totalPages - 1 && activePage >= totalPages - 3) {
-    pages.push(generatePageNumber(totalPages - 1, activePage, onChange));
+    pages.push(generatePageNumber(totalPages - 1, activePage, onPageChange));
   }
 
   // Always add the last page
   if (totalPages !== 1) {
-    pages.push(generatePageNumber(totalPages, activePage, onChange));
+    pages.push(generatePageNumber(totalPages, activePage, onPageChange));
   }
 
   return pages;
 };
 
-const generatePageNumber = (pageNumber: number, active?: number, onChange?: (page: number) => void) => (
+const generatePageNumber = (pageNumber: number, active?: number, onPageChange?: (page: number) => void) => (
   <li
     key={pageNumber}
     className={clsx('rvo-pagination__item', active === pageNumber && 'rvo-pagination__item--active')}
@@ -91,7 +89,7 @@ const generatePageNumber = (pageNumber: number, active?: number, onChange?: (pag
       href="#"
       onClick={(e) => {
         e.preventDefault();
-        onChange?.(pageNumber);
+        onPageChange?.(pageNumber);
       }}
       aria-current={active === pageNumber ? 'page' : undefined}
     >
@@ -109,9 +107,11 @@ const generateEllipses = (key: string) => {
 };
 
 export const Pagination: React.FC<IPaginationProps> = ({
-  numberOfPages = defaultArgs.numberOfPages,
   activePage = defaultArgs.activePage,
-  onChange,
+  className,
+  numberOfPages = defaultArgs.numberOfPages,
+  onPageChange,
+  ...htmlAttributes
 }: IPaginationProps) => {
   // Define internal active page state based on the activePage prop
   const [internalActivePage, setInternalActivePage] = useState(activePage);
@@ -134,7 +134,7 @@ export const Pagination: React.FC<IPaginationProps> = ({
   // Define a function to handle page changes
   const handlePageChange = (newPage: number) => {
     setInternalActivePage(newPage);
-    onChange?.(newPage);
+    onPageChange?.(newPage);
   };
 
   const pageNumbers = useMemo(
@@ -143,15 +143,15 @@ export const Pagination: React.FC<IPaginationProps> = ({
   );
 
   return (
-    <nav className="rvo-pagination">
+    <nav className={clsx('rvo-pagination', className)} {...htmlAttributes}>
       {numberOfPages > 1 && internalActivePage > 1 && (
         <div className="rvo-pagination__prev">
           <Link
-            href="#"
-            showIcon="before"
-            icon="delta-naar-links"
             aria-label="Delta naar links"
+            href="#"
+            icon="delta-naar-links"
             onClick={() => handlePageChange(internalActivePage - 1)}
+            showIcon="before"
           >
             Vorige
           </Link>
@@ -161,11 +161,11 @@ export const Pagination: React.FC<IPaginationProps> = ({
       {numberOfPages > 1 && internalActivePage < numberOfPages && (
         <div className="rvo-pagination__next">
           <Link
-            href="#"
-            showIcon="after"
-            icon="delta-naar-rechts"
             aria-label="Delta naar rechts"
+            href="#"
+            icon="delta-naar-rechts"
             onClick={() => handlePageChange(internalActivePage + 1)}
+            showIcon="after"
           >
             Volgende
           </Link>


### PR DESCRIPTION
Pagination now has className prop and html atrributes props forwarded to the root element. 
NOTE: the `onChange` prop has been renamed to `onPageChange` to make it more distinct and prevent conflicts with HTML attributes `onChange`. 
