### PR TITLE
ROOS-129: allow autoFocus prop to be forwarded to TextInput

### DIFF
--- a/.changeset/poor-hornets-cry.md
+++ b/.changeset/poor-hornets-cry.md
@@ -1,0 +1,5 @@
+---
+"@nl-rvo/css-form-textinput": minor
+---
+
+allow autoFocus prop to be forwarded to TextInput

--- a/components/form-textinput/src/template.tsx
+++ b/components/form-textinput/src/template.tsx
@@ -37,6 +37,9 @@ export interface ITextInputProps extends Omit<TextboxProps, 'size'> {
 }
 
 export const argTypes = {
+  autoFocus: {
+    control: 'boolean',
+  },
   id: { control: 'text' },
   type: {
     options: ['text', 'password', 'email', 'tel', 'url', 'search', 'number', 'date', 'time', 'datetime-local'],


### PR DESCRIPTION
allow autoFocus prop to be forwarded to TextInput