### PR TITLE
prevent ellipses to show when not needed

### DIFF
--- a/.changeset/large-apples-dance.md
+++ b/.changeset/large-apples-dance.md
@@ -1,0 +1,5 @@
+---
+"@nl-rvo/component-library-react": patch
+---
+
+Do not show ellipses in page number navigation when not needed

--- a/packages/component-library-react/src/components/page-number-navigation/index.tsx
+++ b/packages/component-library-react/src/components/page-number-navigation/index.tsx
@@ -22,7 +22,7 @@ const generatePageNumbers = (
   onPageChange?: IPageNumberNavigation['onPageChange'],
 ): ReactNode[] => {
   const pages: ReactNode[] = [];
-  const windowSize = 5;
+  const maxPagePositions = 7;
 
   // helper
   const addRange = (from: number, to: number) => {
@@ -31,25 +31,25 @@ const generatePageNumbers = (
     }
   };
 
-  if (totalPages <= windowSize) {
+  if (totalPages <= maxPagePositions) {
     // 1..N
     addRange(1, totalPages);
     return pages;
   }
 
   // Begin: 1 2 3 4 5 ... last
-  if (activePage <= 3) {
-    addRange(1, 5);
+  if (activePage <= 4) {
+    addRange(1, maxPagePositions - 2);
     pages.push(generateEllipses('ellipses-end'));
     pages.push(generatePageNumber(totalPages, activePage, onPageChange));
     return pages;
   }
 
   // Eind: 1 ... last-4 last-3 last-2 last-1 last
-  if (activePage >= totalPages - 2) {
+  if (activePage >= totalPages - 3) {
     pages.push(generatePageNumber(1, activePage, onPageChange));
     pages.push(generateEllipses('ellipses-start'));
-    addRange(totalPages - 4, totalPages);
+    addRange(totalPages - (maxPagePositions - 3), totalPages);
     return pages;
   }
 


### PR DESCRIPTION
Ik heb het PageNumberNavigation Reactief component aangepast.

Reden: Ellipses worden getoond terwijl dat niet nodig is. 

Voorbeelden:

<img width="574" height="187" alt="Screenshot 2026-05-07 at 14 00 13" src="https://github.com/user-attachments/assets/bba4661c-1d04-4db2-aae4-475100332901" />

<img width="532" height="46" alt="Screenshot 2026-05-07 at 14 18 47" src="https://github.com/user-attachments/assets/6e7e1226-a23c-4e52-abe1-6ce40a40b940" />


In het eerste voorbeeld kan pagina 2 gewoon worden getoond. Een ellipses zorgt eerder voor verwarring dan voor duidelijkheid m.i..
In het tweede voorbeeld is het wellicht nog duidelijker dat de ellipses overbodig zijn.

Onderstaand voorbeelden van dezelfde pagina reeksen na de fix:

<img width="674" height="215" alt="Screenshot 2026-05-07 at 14 09 17" src="https://github.com/user-attachments/assets/14455fd5-21fd-4d96-9c9f-5ee84802db52" />
<img width="655" height="212" alt="Screenshot 2026-05-07 at 14 08 45" src="https://github.com/user-attachments/assets/1fc592b7-db1b-4b5b-a494-6b4b7e400dd9" />

Na de fix is de implementatie ook in lijn met de documentatie:

<img width="137" height="274" alt="image" src="https://github.com/user-attachments/assets/21a2c806-d26e-418f-9ebd-c2a6303be0c1" />
