### PR TITLE
Herstel links in componentdocumentatie

### DIFF
--- a/components/card/README.mdx
+++ b/components/card/README.mdx
@@ -1,4 +1,4 @@
-<!-- @license CC0-1.0 -->
+{/* @license CC0-1.0 */}
 
 Een card groepeert informatie die gerelateerd is aan elkaar. Over het algemeen is het mogelijk om via de card door te klikken naar meer informatie over het onderwerp.
 
@@ -34,5 +34,12 @@ Vanuit de Rijkshuisstijl zijn er geen richtlijnen wat betreft het card component
 
 # Bronnen
 
-- [Cards: UI-Component Definition](https://web.archive.org/web/20220309101808/https://www.nngroup.com/articles/cards-component/)
-- [How to design better cards - Kai Wong](https://uxdesign.cc/how-to-design-better-cards-2a5fa087b6c9)
+- <a
+    href="https://web.archive.org/web/20220309101808/https://www.nngroup.com/articles/cards-component/"
+    className="rvo-link"
+  >
+    Cards: UI-Component Definition
+  </a>
+- <a href="https://uxdesign.cc/how-to-design-better-cards-2a5fa087b6c9" className="rvo-link">
+    How to design better cards - Kai Wong
+  </a>

--- a/components/card/docs/card.docpage.mdx
+++ b/components/card/docs/card.docpage.mdx
@@ -1,7 +1,7 @@
 import { Changelog, Readme } from "@nl-rvo/storybook/config/storybook-blocks";
 import { Canvas, Controls, Meta, Title } from "@storybook/addon-docs/blocks";
 import changeLog from "../CHANGELOG.md";
-import documentation from "../README.md";
+import documentation from "../README.mdx";
 import * as CardStories from "../stories/card.stories";
 
 <Meta of={CardStories} name="Documentatie" />

--- a/components/card/docs/card.docusaurus.mdx
+++ b/components/card/docs/card.docusaurus.mdx
@@ -7,7 +7,7 @@ slug: /card
 
 import { Card } from "@nl-rvo/component-library-react";
 import ComponentExample from "@site/src/components/ComponentExample";
-import Documentation from "../README.md";
+import Documentation from "../README.mdx";
 
 <ComponentExample storyName="componenten-card--default">
   <Card />

--- a/components/dialog/README.mdx
+++ b/components/dialog/README.mdx
@@ -39,4 +39,9 @@ Vanuit de Rijkshuisstijl zijn er geen richtlijnen wat betreft dialogen.
 
 ## Bronnen
 
-- [Modal & Nonmodal Dialogs: When (& When Not) to Use Them - Therese Fessenden](https://web.archive.org/web/20211006165951/https://www.nngroup.com/articles/modal-nonmodal-dialog/)
+- <a
+    href="https://web.archive.org/web/20211006165951/https://www.nngroup.com/articles/modal-nonmodal-dialog/"
+    className="rvo-link"
+  >
+    Modal & Nonmodal Dialogs: When (& When Not) to Use Them - Therese Fessenden
+  </a>

--- a/components/dialog/docs/dialog.docpage.mdx
+++ b/components/dialog/docs/dialog.docpage.mdx
@@ -1,7 +1,7 @@
 import { Changelog, Readme } from "@nl-rvo/storybook/config/storybook-blocks";
 import { Canvas, Controls, Meta, Title } from "@storybook/addon-docs/blocks";
 import changeLog from "../CHANGELOG.md";
-import documentation from "../README.md";
+import documentation from "../README.mdx";
 import * as DialogStories from "../stories/dialog.stories";
 
 <Meta of={DialogStories} name="Documentatie" />

--- a/components/dialog/docs/dialog.docusaurus.mdx
+++ b/components/dialog/docs/dialog.docusaurus.mdx
@@ -7,7 +7,7 @@ slug: /dialog
 
 import { Dialog } from "@nl-rvo/component-library-react";
 import ComponentExample from "@site/src/components/ComponentExample";
-import Documentation from "../README.md";
+import Documentation from "../README.mdx";
 
 <ComponentExample storyName="componenten-dialog--default">
   <Dialog />

--- a/components/favicon/README.mdx
+++ b/components/favicon/README.mdx
@@ -1,4 +1,4 @@
-<!-- @license CC0-1.0 -->
+{/* @license CC0-1.0 */}
 
 # Favicon
 
@@ -27,9 +27,13 @@ Een favicon bestaat uit:
 
 ## Rijkshuisstijl
 
-De Rijkshuisstijl [richtlijnen](https://www.rijkshuisstijl.nl/basiselementen/basiselementen-online/logo) zijn aangehouden en uitgebreid met een svg icoon, apple touch icoon en iconen voor progressive web applications.
+De Rijkshuisstijl <a href="https://www.rijkshuisstijl.nl/basiselementen/basiselementen-online/logo" className="rvo-link">richtlijnen</a> zijn aangehouden en uitgebreid met een svg icoon, apple touch icoon en iconen voor progressive web applications.
 
 ## Bronnen
 
-- [How to Favicon in 2022:
-  Six files that fit most needs - Andrey Sitnik](https://web.archive.org/web/20220707164647/https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs)
+- <a
+    href="https://web.archive.org/web/20220707164647/https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs"
+    className="rvo-link"
+  >
+    How to Favicon in 2022: Six files that fit most needs - Andrey Sitnik
+  </a>

--- a/components/favicon/docs/favicon.docpage.mdx
+++ b/components/favicon/docs/favicon.docpage.mdx
@@ -2,7 +2,7 @@ import { Favicon } from "@nl-rvo/component-library-react";
 import { Changelog, Readme } from "@nl-rvo/storybook/config/storybook-blocks";
 import { Meta } from "@storybook/addon-docs/blocks";
 import changeLog from "../CHANGELOG.md";
-import documentation from "../README.md";
+import documentation from "../README.mdx";
 
 <Meta title="Componenten/Favicon/Documentatie" />
 

--- a/components/favicon/docs/favicon.docusaurus.mdx
+++ b/components/favicon/docs/favicon.docusaurus.mdx
@@ -8,7 +8,7 @@ slug: /favicon
 import { Favicon } from "@nl-rvo/component-library-react";
 import ComponentExample from "@site/src/components/ComponentExample";
 import FavIconUrl from "../../../documentation/demopages/common/favicon.ico";
-import Documentation from "../README.md";
+import Documentation from "../README.mdx";
 
 {(() => {
 const props = { src: FavIconUrl };

--- a/components/form-field-label/README.mdx
+++ b/components/form-field-label/README.mdx
@@ -26,6 +26,21 @@ Dit component volgt de richtlijnen zoals deze zijn opgesteld door de Rijkshuisst
 
 ## Bronnen
 
-- [Simple is better - Making your web forms easy to use pays off](https://web.archive.org/web/20211122232910/https://ai.googleblog.com/2014/07/simple-is-better-making-your-web-forms.html)
-- [Formuliervelden op de Rijkshuisstijl](https://web.archive.org/web/20190603044428/https://www.rijkshuisstijl.nl/basiselementen/basiselementen-online/online-componenten/formuliervelden)
-- [Website Forms Usability: Top 10 Recommendations](https://web.archive.org/web/20210421051618/https://www.nngroup.com/articles/web-form-design/)
+- <a
+    href="https://web.archive.org/web/20211122232910/https://ai.googleblog.com/2014/07/simple-is-better-making-your-web-forms.html"
+    className="rvo-link"
+  >
+    Simple is better - Making your web forms easy to use pays off
+  </a>
+- <a
+    href="https://web.archive.org/web/20190603044428/https://www.rijkshuisstijl.nl/basiselementen/basiselementen-online/online-componenten/formuliervelden"
+    className="rvo-link"
+  >
+    Formuliervelden op de Rijkshuisstijl
+  </a>
+- <a
+    href="https://web.archive.org/web/20210421051618/https://www.nngroup.com/articles/web-form-design/"
+    className="rvo-link"
+  >
+    Website Forms Usability: Top 10 Recommendations
+  </a>

--- a/components/form-field-label/docs/label.docpage.mdx
+++ b/components/form-field-label/docs/label.docpage.mdx
@@ -2,7 +2,7 @@ import { Changelog, Readme } from "@nl-rvo/storybook/config/storybook-blocks";
 import { Canvas, Controls, Markdown, Meta, Title } from "@storybook/addon-docs/blocks";
 import fieldDocumentation from "../../form-field/README.md";
 import changeLog from "../CHANGELOG.md";
-import documentation from "../README.md";
+import documentation from "../README.mdx";
 import * as LabelStories from "../stories/label.stories";
 
 <Meta of={LabelStories} name="Documentatie" />

--- a/components/form-field-label/docs/label.docusaurus.mdx
+++ b/components/form-field-label/docs/label.docusaurus.mdx
@@ -8,7 +8,7 @@ slug: /form-field-label
 import { Label } from "@nl-rvo/component-library-react";
 import ComponentExample from "@site/src/components/ComponentExample";
 import FieldDocumentation from "../../form-field/README.md";
-import Documentation from "../README.md";
+import Documentation from "../README.mdx";
 
 <ComponentExample storyName="componenten-label--default">
   <Label />

--- a/components/form-field-textinput/README.mdx
+++ b/components/form-field-textinput/README.mdx
@@ -1,4 +1,4 @@
-<!-- @license CC0-1.0 -->
+{/* @license CC0-1.0 */}
 
 Een text input veld is een invoerveld waarmee gebruikers tekst kunnen invoeren.
 
@@ -36,5 +36,15 @@ Vanuit de Rijkshuisstijl zijn er geen specifieke richtlijnen wat betreft het tex
 
 # Bronnen
 
-- [The problem with placeholders and what to do instead](https://web.archive.org/web/20250511143112/https://adamsilver.io/blog/the-problem-with-placeholders-and-what-to-do-instead/)
-- [Why the Email Confirmation Field Must Die](https://web.archive.org/web/20250328104206/https://uxmovement.com/forms/why-the-email-confirmation-field-must-die/)
+- <a
+    href="https://web.archive.org/web/20250511143112/https://adamsilver.io/blog/the-problem-with-placeholders-and-what-to-do-instead/"
+    className="rvo-link"
+  >
+    The problem with placeholders and what to do instead
+  </a>
+- <a
+    href="https://web.archive.org/web/20250328104206/https://uxmovement.com/forms/why-the-email-confirmation-field-must-die/"
+    className="rvo-link"
+  >
+    Why the Email Confirmation Field Must Die
+  </a>

--- a/components/form-field-textinput/docs/form-field-textinput.docpage.mdx
+++ b/components/form-field-textinput/docs/form-field-textinput.docpage.mdx
@@ -2,7 +2,7 @@ import { Changelog, Readme } from "@nl-rvo/storybook/config/storybook-blocks";
 import { Canvas, Controls, Markdown, Meta, Title } from "@storybook/addon-docs/blocks";
 import fieldDocumentation from "../../form-field/README.md";
 import changeLog from "../CHANGELOG.md";
-import documentation from "../README.md";
+import documentation from "../README.mdx";
 import * as FormFieldTextInputStories from "../stories/form-field-textinput.stories";
 
 <Meta of={FormFieldTextInputStories} name="Documentatie" />

--- a/components/form-field-textinput/docs/form-field-textinput.docusaurus.mdx
+++ b/components/form-field-textinput/docs/form-field-textinput.docusaurus.mdx
@@ -8,7 +8,7 @@ slug: /form-field-textinput
 import { TextInputField } from "@nl-rvo/component-library-react";
 import ComponentExample from "@site/src/components/ComponentExample";
 import FieldDocumentation from "../../form-field/README.md";
-import Documentation from "../README.md";
+import Documentation from "../README.mdx";
 
 <ComponentExample storyName="componenten-textinput-field--default">
   <TextInputField />

--- a/components/max-width-layout/README.mdx
+++ b/components/max-width-layout/README.mdx
@@ -20,4 +20,9 @@ Er zijn geen richtlijnen vanuit de Rijkshuisstijl betreffende de maximale breedt
 
 ## Bronnen
 
-- [Readability: The Optimal Line Length - Baymard Institute](https://web.archive.org/web/20220606133257/https://baymard.com/blog/line-length-readability)
+- <a
+    href="https://web.archive.org/web/20220606133257/https://baymard.com/blog/line-length-readability"
+    className="rvo-link"
+  >
+    Readability: The Optimal Line Length - Baymard Institute
+  </a>

--- a/components/max-width-layout/docs/max-width-layout.docpage.mdx
+++ b/components/max-width-layout/docs/max-width-layout.docpage.mdx
@@ -1,7 +1,7 @@
 import { Changelog, Readme } from "@nl-rvo/storybook/config/storybook-blocks";
 import { Canvas, Controls, Meta, Title } from "@storybook/addon-docs/blocks";
 import changeLog from "../CHANGELOG.md";
-import documentation from "../README.md";
+import documentation from "../README.mdx";
 import * as MaxWidthLayoutStories from "../stories/max-width-layout.stories";
 
 <Meta of={MaxWidthLayoutStories} name="Documentatie" />

--- a/components/max-width-layout/docs/max-width-layout.docusaurus.mdx
+++ b/components/max-width-layout/docs/max-width-layout.docusaurus.mdx
@@ -7,7 +7,7 @@ slug: /max-width-layout
 
 import { MaxWidthLayout } from "@nl-rvo/component-library-react";
 import ComponentExample from "@site/src/components/ComponentExample";
-import Documentation from "../README.md";
+import Documentation from "../README.mdx";
 
 <ComponentExample storyName="layout-max-width-layout--default">
   <MaxWidthLayout />

--- a/components/paragraph/README.mdx
+++ b/components/paragraph/README.mdx
@@ -1,5 +1,3 @@
-import { Link } from "@nl-rvo/component-library-react";
-
 # Paragraph
 
 ## Wanneer gebruik je een paragraph?
@@ -12,16 +10,28 @@ Je gebruikt de paragraph om een stuk tekst te tonen in een bepaalde stijl.
 
 ## Bronnen
 
-- <Link href="http://web.archive.org/web/20240415162622/https://www.sciencedirect.com/science/article/abs/pii/S1071581901904586">
+- <a
+    href="http://web.archive.org/web/20240415162622/https://www.sciencedirect.com/science/article/abs/pii/S1071581901904586"
+    className="rvo-link"
+  >
     The influence of reading speed and line length on the effectiveness of reading from screen - Dyson & Haselgrove
     (2001)
-  </Link>
-- <Link href="http://web.archive.org/web/20250526110231/https://journals.uc.edu/index.php/vl/article/view/5765">
+  </a>
+- <a
+    href="http://web.archive.org/web/20250526110231/https://journals.uc.edu/index.php/vl/article/view/5765"
+    className="rvo-link"
+  >
     Optimal Line Length in Reading — A Literature Review - Ling & van Schaik (2005)
-  </Link>
-- <Link href="http://web.archive.org/web/20260427041919/https://baymard.com/blog/line-length-readability">
+  </a>
+- <a
+    href="http://web.archive.org/web/20260427041919/https://baymard.com/blog/line-length-readability"
+    className="rvo-link"
+  >
     Line Length Readability - Baymard Institute
-  </Link>
-- <Link href="http://web.archive.org/web/20260513074008/https://www.w3.org/TR/WCAG21/#visual-presentation">
+  </a>
+- <a
+    href="http://web.archive.org/web/20260513074008/https://www.w3.org/TR/WCAG21/#visual-presentation"
+    className="rvo-link"
+  >
     WCAG 2.1 succescriterium 1.4.8 Visuele weergave
-  </Link>
+  </a>

--- a/components/skeleton/README.mdx
+++ b/components/skeleton/README.mdx
@@ -1,4 +1,4 @@
-De Skeleton is volgens de [Atomic Design Methodology](https://atomicdesign.bradfrost.com/chapter-2/) het kleinst
+De Skeleton is volgens de <a href="https://atomicdesign.bradfrost.com/chapter-2/" className="rvo-link">Atomic Design Methodology</a> het kleinst
 mogelijke bouwblok. Dit bouwblok dient daarom gebruikt te worden bij het maken van complexere componenten. Een
 mogelijk component waarbij de Skeleton gebruikt kan worden is een skeleton loader. Deze loader kan vervolgens
 getoond worden bij asynchrone operaties waarbij nieuwe informatie word opgehaald.

--- a/components/skeleton/docs/skeleton.docpage.mdx
+++ b/components/skeleton/docs/skeleton.docpage.mdx
@@ -1,7 +1,7 @@
 import { Changelog, Readme } from "@nl-rvo/storybook/config/storybook-blocks";
 import { Canvas, Controls, Meta, Title } from "@storybook/addon-docs/blocks";
 import changeLog from "../CHANGELOG.md";
-import documentation from "../README.md";
+import documentation from "../README.mdx";
 import * as SkeletonStories from "../stories/skeleton.stories";
 
 <Meta of={SkeletonStories} name="Documentatie" />

--- a/components/skeleton/docs/skeleton.docusaurus.mdx
+++ b/components/skeleton/docs/skeleton.docusaurus.mdx
@@ -7,7 +7,7 @@ slug: /skeleton
 
 import { Skeleton } from "@nl-rvo/component-library-react";
 import ComponentExample from "@site/src/components/ComponentExample";
-import Documentation from "../README.md";
+import Documentation from "../README.mdx";
 
 ## Standard component:
 

--- a/components/table/README.mdx
+++ b/components/table/README.mdx
@@ -36,7 +36,7 @@ Een tabel bestaat uit:
 - Tekst in een cell begint met een hoofdletter
 - Data in een cell bevat geen meeteenheid. Die zet je in de header.
 - Wees consistent in het gebruik van decimalen.
-- De sortering wordt toegepast op alle items en over alle pagina’s als er paginering is
+- De sortering wordt toegepast op alle items en over alle pagina's als er paginering is
 - Kolommen die gesorteerd kunnen worden hebben een sorteer icoon.
 
 ## Rijkshuisstijl
@@ -45,5 +45,15 @@ De Rijkshuisstijl kent geen specifieke voorschriften wat betreft tabellen.
 
 ## Bronnen
 
-- [Data Tables](https://web.archive.org/web/20220315222659/https://inclusive-components.design/data-tables/)
-- [Designing Mobile Tables - Steven Hoober](https://web.archive.org/web/20211221193450/https://www.uxmatters.com/mt/archives/2020/07/designing-mobile-tables.php)
+- <a
+    href="https://web.archive.org/web/20220315222659/https://inclusive-components.design/data-tables/"
+    className="rvo-link"
+  >
+    Data Tables
+  </a>
+- <a
+    href="https://web.archive.org/web/20211221193450/https://www.uxmatters.com/mt/archives/2020/07/designing-mobile-tables.php"
+    className="rvo-link"
+  >
+    Designing Mobile Tables - Steven Hoober
+  </a>

--- a/components/table/docs/table.docpage.mdx
+++ b/components/table/docs/table.docpage.mdx
@@ -1,7 +1,7 @@
 import { Changelog, Readme } from "@nl-rvo/storybook/config/storybook-blocks";
 import { Canvas, Controls, Meta, Title } from "@storybook/addon-docs/blocks";
 import changeLog from "../CHANGELOG.md";
-import documentation from "../README.md";
+import documentation from "../README.mdx";
 import * as TableStories from "../stories/table.stories";
 
 <Meta of={TableStories} name="Documentatie" />

--- a/components/table/docs/table.docusaurus.mdx
+++ b/components/table/docs/table.docusaurus.mdx
@@ -7,7 +7,7 @@ slug: /table
 
 import { Table } from "@nl-rvo/component-library-react";
 import ComponentExample from "@site/src/components/ComponentExample";
-import Documentation from "../README.md";
+import Documentation from "../README.mdx";
 
 <ComponentExample storyName="componenten-table--default">
   <Table />

--- a/components/tabs/README.mdx
+++ b/components/tabs/README.mdx
@@ -20,7 +20,7 @@ Het component bestaat uit:
 - Gebruik tabs niet als gebruikers alle content in één keer moeten kunnen zien, lezen of vergelijken.
 - Gebruik tabs niet als de totale hoeveelheid content de pagina traag maakt om te laden.
 - Gebruik tabs niet als vervanging van paginanavigatie.
-- Test eerst of de content zonder tabs duidelijk is. Overweeg of het beter is om de content te versimpelen, over meerdere pagina’s te verdelen, op één pagina te houden met kopjes, of een inhoudsopgave te gebruiken.
+- Test eerst of de content zonder tabs duidelijk is. Overweeg of het beter is om de content te versimpelen, over meerdere pagina's te verdelen, op één pagina te houden met kopjes, of een inhoudsopgave te gebruiken.
 - Gebruik tabs als gebruikers niet meer dan één sectie tegelijk hoeven te zien en snel willen wisselen.
 
 ## Rijkshuisstijl
@@ -29,4 +29,9 @@ De Rijkshuisstijl heeft geen specifieke eisen of richtlijnen wat betreft tabs.
 
 ## Bronnen
 
-- [Tabs - GOV.UK Design System](https://web.archive.org/web/20240830090226/https://design-system.service.gov.uk/components/tabs/)
+- <a
+    href="https://web.archive.org/web/20240830090226/https://design-system.service.gov.uk/components/tabs/"
+    className="rvo-link"
+  >
+    Tabs - GOV.UK Design System
+  </a>

--- a/components/tabs/docs/tabs.docpage.mdx
+++ b/components/tabs/docs/tabs.docpage.mdx
@@ -1,7 +1,7 @@
 import { Changelog, Readme } from "@nl-rvo/storybook/config/storybook-blocks";
 import { Canvas, Controls, Meta, Title } from "@storybook/addon-docs/blocks";
 import changeLog from "../CHANGELOG.md";
-import documentation from "../README.md";
+import documentation from "../README.mdx";
 import * as TabsStories from "../stories/tabs.stories";
 
 <Meta of={TabsStories} name="Documentatie" />

--- a/components/tabs/docs/tabs.docusaurus.mdx
+++ b/components/tabs/docs/tabs.docusaurus.mdx
@@ -7,7 +7,7 @@ slug: /tabs
 
 import { Tabs } from "@nl-rvo/component-library-react";
 import ComponentExample from "@site/src/components/ComponentExample";
-import Documentation from "../README.md";
+import Documentation from "../README.mdx";
 
 <ComponentExample storyName="componenten-tabs--default">
   <Tabs />


### PR DESCRIPTION
Converteer README.md naar README.mdx voor componenten met bronlinks, zodat rvo-link-klasse correct wordt toegepast. Vervang <Link>-component door <a className="rvo-link"> in paragraph om ongewenste witruimte te verwijderen.