### PR TITLE
fix(footer): voorkom ongewenste <p>-wrappers na links in footer docs

### DIFF
--- a/components/footer/README.mdx
+++ b/components/footer/README.mdx
@@ -14,7 +14,7 @@ Een Footer bestaat uit:
 - Optionele pay-off
 - Verplichte links aan de onderkant van de footer:
 
-<!-- prettier-ignore -->
+{/* prettier-ignore */}
 <ul>
   <li>Contact: verwijst naar een contactpagina.</li>
   <li><a href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#privacy" className="rvo-link">Privacy</a>: verwijst naar een pagina met informatie over Privacy.</li>

--- a/components/footer/README.mdx
+++ b/components/footer/README.mdx
@@ -13,47 +13,17 @@ Een Footer bestaat uit:
 - Optionele lijsten met links
 - Optionele pay-off
 - Verplichte links aan de onderkant van de footer:
-  <ul>
-    <li>Contact: verwijst naar een contactpagina.</li>
-    <li>
-      <a href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#privacy" className="rvo-link">
-        Privacy
-      </a>
-      : verwijst naar een pagina met informatie over Privacy.
-    </li>
-    <li>
-      <a href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#cookies" className="rvo-link">
-        Cookies en/of anti-spam
-      </a>
-      : verwijst naar een pagina met informatie over de Cookies die geplaatst worden en/of anti-spam maatregelen die genomen
-      worden.
-    </li>
-    <li>
-      <a
-        href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#toegankelijkheid"
-        className="rvo-link"
-      >
-        Toegankelijkheid
-      </a>
-      : verwijst naar de toegankelijkheidsverklaring van de website of applicatie.
-    </li>
-    <li>Proclaimer: verwijst naar de Proclaimer van de website.</li>
-    <li>
-      <a
-        href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#kwetsbaarheid-melden"
-        className="rvo-link"
-      >
-        Kwetsbaarheid melden
-      </a>
-      : verwijst naar de kwetsbaarheid melden pagina op de website van RVO.
-    </li>
-    <li>
-      <a href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#archief" className="rvo-link">
-        Webarchief
-      </a>
-      : verwijst naar de archivering van de website of applicatie.
-    </li>
-  </ul>
+
+<!-- prettier-ignore -->
+<ul>
+  <li>Contact: verwijst naar een contactpagina.</li>
+  <li><a href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#privacy" className="rvo-link">Privacy</a>: verwijst naar een pagina met informatie over Privacy.</li>
+  <li><a href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#cookies" className="rvo-link">Cookies en/of anti-spam</a>: verwijst naar een pagina met informatie over de Cookies die geplaatst worden en/of anti-spam maatregelen die genomen worden.</li>
+  <li><a href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#toegankelijkheid" className="rvo-link">Toegankelijkheid</a>: verwijst naar de toegankelijkheidsverklaring van de website of applicatie.</li>
+  <li>Proclaimer: verwijst naar de Proclaimer van de website.</li>
+  <li><a href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#kwetsbaarheid-melden" className="rvo-link">Kwetsbaarheid melden</a>: verwijst naar de kwetsbaarheid melden pagina op de website van RVO.</li>
+  <li><a href="https://nl-design-system.github.io/rvo/docs/schrijfwijzer/Servicepagina's/#archief" className="rvo-link">Webarchief</a>: verwijst naar de archivering van de website of applicatie.</li>
+</ul>
 
 ## Richtlijnen
 

--- a/components/footer/README.mdx
+++ b/components/footer/README.mdx
@@ -12,7 +12,9 @@ Een Footer bestaat uit:
 
 - Optionele lijsten met links
 - Optionele pay-off
-- Verplichte links aan de onderkant van de footer:
+- Verplichte links aan de onderkant van de footer.
+
+### Verplichte footer links
 
 {/* prettier-ignore */}
 <ul>


### PR DESCRIPTION
Prettier zette tekst na </a> op een nieuwe regel, waardoor MDX die tekst als paragraph parseerde. Opgelost met prettier-ignore en links aaneengesloten op één regel per lijstitem.