### PR TITLE
ci: fix zizmor checking the wrong branch

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,9 +3,11 @@ name: zizmor
 on:
   pull_request:
     branches:
+      - master
       - main
   push:
     branches:
+      - master
       - main
 
 concurrency:


### PR DESCRIPTION
There is an open question on using `main` instead of `master`.  Until that is resolved, this ensures zizmor scans the proper branch.
