### PR TITLE
chore: upgrade npm-check-updates to 22

### DIFF
--- a/.ncurc.major.mjs
+++ b/.ncurc.major.mjs
@@ -1,6 +1,6 @@
-const minorConfig = require('./.ncurc.minor.cjs');
+import minorConfig from './.ncurc.minor.mjs';
 
-module.exports = {
+export default {
   ...minorConfig,
   reject: [
     ...minorConfig.reject,
@@ -17,5 +17,3 @@ module.exports = {
   ],
   target: 'latest',
 };
-
-console.log(`Reject major updates of:\n\n${module.exports.reject.join('\n')}`);

--- a/.ncurc.minor.mjs
+++ b/.ncurc.minor.mjs
@@ -1,6 +1,6 @@
-const patchConfig = require('./.ncurc.patch.cjs');
+import patchConfig from './.ncurc.patch.mjs';
 
-module.exports = {
+export default {
   ...patchConfig,
   reject: [...patchConfig.reject, 'typescript'],
   target: 'minor',

--- a/.ncurc.patch.mjs
+++ b/.ncurc.patch.mjs
@@ -1,5 +1,4 @@
-module.exports = {
-  cooldown: 1, // 1 day
+export default {
   dep: ['dev', 'prod'],
   install: 'always',
   reject: [],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint-staged": "15.2.2",
     "markdownlint-cli": "0.47.0",
     "normalize.css": "8.0.1",
-    "npm-check-updates": "19.0.0",
+    "npm-check-updates": "22.2.9",
     "npm-package-json-lint": "7.1.0",
     "npm-run-all": "4.1.5",
     "postcss": "8.4.42",
@@ -83,9 +83,9 @@
     "test": "pnpm run --recursive test",
     "test-build": "pnpm run --recursive test-build",
     "test-update": "npm-run-all --sequential clean lint build test",
-    "update-patch": "npm-check-updates --configFileName .ncurc.patch.cjs",
-    "update-minor": "npm-check-updates --configFileName .ncurc.minor.cjs",
-    "update-major": "npm-check-updates --configFileName .ncurc.major.cjs"
+    "update-patch": "npm-check-updates --configFileName .ncurc.patch.mjs",
+    "update-minor": "npm-check-updates --configFileName .ncurc.minor.mjs",
+    "update-major": "npm-check-updates --configFileName .ncurc.major.mjs"
   },
   "dependencies": {
     "http-server": "14.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,8 @@ importers:
         specifier: 8.0.1
         version: 8.0.1
       npm-check-updates:
-        specifier: 19.0.0
-        version: 19.0.0
+        specifier: 22.2.9
+        version: 22.2.9
       npm-package-json-lint:
         specifier: 7.1.0
         version: 7.1.0(typescript@5.5.2)
@@ -630,7 +630,7 @@ importers:
         version: 2.1.1
       cssnano:
         specifier: 7.0.6
-        version: 7.0.6(postcss@8.5.6)
+        version: 7.0.6(postcss@8.4.42)
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -642,7 +642,7 @@ importers:
         version: 10.0.0
       rollup-plugin-postcss:
         specifier: 4.0.2
-        version: 4.0.2(postcss@8.5.6)
+        version: 4.0.2(postcss@8.4.42)
       sass-embedded:
         specifier: 1.71.1
         version: 1.71.1
@@ -812,7 +812,7 @@ importers:
         version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.1)(react@18.3.1))(@rspack/core@1.6.6(@swc/helpers@0.5.17))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
       '@docusaurus/plugin-rsdoctor':
         specifier: 3.9.2
-        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.1)(react@18.3.1))(@rspack/core@1.6.6(@swc/helpers@0.5.17))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(webpack@5.105.0)
+        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.1)(react@18.3.1))(@rspack/core@1.6.6(@swc/helpers@0.5.17))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(webpack@5.96.1)
       '@docusaurus/preset-classic':
         specifier: 3.9.2
         version: 3.9.2(@algolia/client-search@5.45.0)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.1)(react@18.3.1))(@rspack/core@1.6.6(@swc/helpers@0.5.17))(@types/react@18.3.1)(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
@@ -866,7 +866,7 @@ importers:
         version: 1.81.0
       sass-loader:
         specifier: 16.0.3
-        version: 16.0.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(sass-embedded@1.81.0)(sass@1.97.2)(webpack@5.105.0)
+        version: 16.0.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(sass-embedded@1.81.0)(sass@1.97.2)(webpack@5.96.1)
       typescript:
         specifier: 5.5.2
         version: 5.5.2
@@ -11190,9 +11190,9 @@ packages:
     resolution: {integrity: sha512-+AvaheE/ww1JEwRHOrn4WHNzOxGtVp+adrg2AeZS/7KuxGUYFuBta98wYpfHBbJp6Tg6j1NKSEVHNcfZzJHQwQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  npm-check-updates@19.0.0:
-    resolution: {integrity: sha512-qcfjZEv6xB+WvW24S8wU1MKISPPiTREraBg62XDo/7zmOLXH3Zj7ti2v/LRfks0qITU8SDZLTWwgIitflvursw==}
-    engines: {node: '>=20.0.0', npm: '>=8.12.1'}
+  npm-check-updates@22.2.9:
+    resolution: {integrity: sha512-DVeZ0KirHfliSsHuR2o7cHE+tW439sVHfJjF6cGWeDiY0Wyl3BI/jS4zV0eixtcMOquFbcF1Su/FsxOvk5MoYA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10.0.0'}
     hasBin: true
 
   npm-install-checks@6.3.0:
@@ -18238,13 +18238,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-rsdoctor@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.1)(react@18.3.1))(@rspack/core@1.6.6(@swc/helpers@0.5.17))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(webpack@5.105.0)':
+  '@docusaurus/plugin-rsdoctor@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.1)(react@18.3.1))(@rspack/core@1.6.6(@swc/helpers@0.5.17))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(webpack@5.96.1)':
     dependencies:
       '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.1)(react@18.3.1))(@rspack/core@1.6.6(@swc/helpers@0.5.17))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
       '@docusaurus/types': 3.9.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.9.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rsdoctor/rspack-plugin': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
-      '@rsdoctor/webpack-plugin': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
+      '@rsdoctor/webpack-plugin': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -20384,34 +20384,11 @@ snapshots:
 
   '@rsdoctor/client@0.4.13': {}
 
-  '@rsdoctor/core@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)':
-    dependencies:
-      '@rsdoctor/graph': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/sdk': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/utils': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      axios: 1.15.0(debug@4.4.0)
-      enhanced-resolve: 5.12.0
-      filesize: 10.1.6
-      fs-extra: 11.3.0
-      lodash: 4.17.21
-      path-browserify: 1.0.1
-      semver: 7.7.3
-      source-map: 0.7.6
-      webpack-bundle-analyzer: 4.10.2
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
   '@rsdoctor/core@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)':
     dependencies:
       '@rsdoctor/graph': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       '@rsdoctor/sdk': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
-      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
+      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       '@rsdoctor/utils': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       axios: 1.15.0(debug@4.4.0)
       enhanced-resolve: 5.12.0
@@ -20426,20 +20403,6 @@ snapshots:
       - '@rspack/core'
       - bufferutil
       - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/graph@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)':
-    dependencies:
-      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/utils': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      lodash.unionby: 4.8.0
-      socket.io: 4.8.1
-      source-map: 0.7.6
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
       - supports-color
       - utf-8-validate
       - webpack
@@ -20463,7 +20426,7 @@ snapshots:
       '@rsdoctor/core': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       '@rsdoctor/graph': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       '@rsdoctor/sdk': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
-      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
+      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       '@rsdoctor/utils': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       '@rspack/core': 1.6.6(@swc/helpers@0.5.17)
       lodash: 4.17.21
@@ -20474,36 +20437,11 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)':
-    dependencies:
-      '@rsdoctor/client': 0.4.13
-      '@rsdoctor/graph': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/utils': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@types/fs-extra': 11.0.4
-      body-parser: 1.20.3
-      cors: 2.8.5
-      dayjs: 1.11.13
-      fs-extra: 11.3.0
-      json-cycle: 1.5.0
-      lodash: 4.17.21
-      open: 8.4.2
-      serve-static: 1.16.2
-      socket.io: 4.8.1
-      source-map: 0.7.6
-      tapable: 2.2.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - webpack
-
   '@rsdoctor/sdk@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)':
     dependencies:
       '@rsdoctor/client': 0.4.13
       '@rsdoctor/graph': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
-      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
+      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       '@rsdoctor/utils': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       '@types/fs-extra': 11.0.4
       body-parser: 1.20.3
@@ -20524,16 +20462,6 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/estree': 1.0.5
-      '@types/tapable': 2.2.7
-      source-map: 0.7.6
-      webpack: 5.105.0
-    optionalDependencies:
-      '@rspack/core': 1.6.6(@swc/helpers@0.5.17)
-
   '@rsdoctor/types@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)':
     dependencies:
       '@types/connect': 3.4.38
@@ -20543,30 +20471,6 @@ snapshots:
       webpack: 5.96.1(@swc/core@1.11.15(@swc/helpers@0.5.17))
     optionalDependencies:
       '@rspack/core': 1.6.6(@swc/helpers@0.5.17)
-
-  '@rsdoctor/utils@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)':
-    dependencies:
-      '@babel/code-frame': 7.25.7
-      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@types/estree': 1.0.5
-      acorn: 8.15.0
-      acorn-import-assertions: 1.9.0(acorn@8.15.0)
-      acorn-walk: 8.3.4
-      chalk: 4.1.2
-      connect: 3.7.0
-      deep-eql: 4.1.4
-      envinfo: 7.14.0
-      filesize: 10.1.6
-      fs-extra: 11.3.0
-      get-port: 5.1.1
-      json-stream-stringify: 3.0.1
-      lines-and-columns: 2.0.4
-      rslog: 1.2.11
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - supports-color
-      - webpack
 
   '@rsdoctor/utils@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)':
     dependencies:
@@ -20592,16 +20496,16 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsdoctor/webpack-plugin@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)':
+  '@rsdoctor/webpack-plugin@0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)':
     dependencies:
-      '@rsdoctor/core': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/graph': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/sdk': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
-      '@rsdoctor/utils': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.105.0)
+      '@rsdoctor/core': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
+      '@rsdoctor/graph': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
+      '@rsdoctor/sdk': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
+      '@rsdoctor/types': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
+      '@rsdoctor/utils': 0.4.13(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.96.1)
       fs-extra: 11.3.0
       lodash: 4.17.21
-      webpack: 5.105.0
+      webpack: 5.96.1(@swc/core@1.11.15(@swc/helpers@0.5.17))
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -23800,17 +23704,17 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
+  css-declaration-sorter@6.4.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+
   css-declaration-sorter@6.4.1(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
 
-  css-declaration-sorter@6.4.1(postcss@8.5.6):
+  css-declaration-sorter@7.2.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
-
-  css-declaration-sorter@7.2.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
 
   css-declaration-sorter@7.3.0(postcss@8.5.6):
     dependencies:
@@ -23957,6 +23861,39 @@ snapshots:
       postcss-reduce-idents: 6.0.3(postcss@8.5.6)
       postcss-zindex: 6.0.2(postcss@8.5.6)
 
+  cssnano-preset-default@5.2.14(postcss@8.4.42):
+    dependencies:
+      css-declaration-sorter: 6.4.1(postcss@8.4.42)
+      cssnano-utils: 3.1.0(postcss@8.4.42)
+      postcss: 8.4.42
+      postcss-calc: 8.2.4(postcss@8.4.42)
+      postcss-colormin: 5.3.1(postcss@8.4.42)
+      postcss-convert-values: 5.1.3(postcss@8.4.42)
+      postcss-discard-comments: 5.1.2(postcss@8.4.42)
+      postcss-discard-duplicates: 5.1.0(postcss@8.4.42)
+      postcss-discard-empty: 5.1.1(postcss@8.4.42)
+      postcss-discard-overridden: 5.1.0(postcss@8.4.42)
+      postcss-merge-longhand: 5.1.7(postcss@8.4.42)
+      postcss-merge-rules: 5.1.4(postcss@8.4.42)
+      postcss-minify-font-values: 5.1.0(postcss@8.4.42)
+      postcss-minify-gradients: 5.1.1(postcss@8.4.42)
+      postcss-minify-params: 5.1.4(postcss@8.4.42)
+      postcss-minify-selectors: 5.2.1(postcss@8.4.42)
+      postcss-normalize-charset: 5.1.0(postcss@8.4.42)
+      postcss-normalize-display-values: 5.1.0(postcss@8.4.42)
+      postcss-normalize-positions: 5.1.1(postcss@8.4.42)
+      postcss-normalize-repeat-style: 5.1.1(postcss@8.4.42)
+      postcss-normalize-string: 5.1.0(postcss@8.4.42)
+      postcss-normalize-timing-functions: 5.1.0(postcss@8.4.42)
+      postcss-normalize-unicode: 5.1.1(postcss@8.4.42)
+      postcss-normalize-url: 5.1.0(postcss@8.4.42)
+      postcss-normalize-whitespace: 5.1.1(postcss@8.4.42)
+      postcss-ordered-values: 5.1.3(postcss@8.4.42)
+      postcss-reduce-initial: 5.1.2(postcss@8.4.42)
+      postcss-reduce-transforms: 5.1.0(postcss@8.4.42)
+      postcss-svgo: 5.1.0(postcss@8.4.42)
+      postcss-unique-selectors: 5.1.1(postcss@8.4.42)
+
   cssnano-preset-default@5.2.14(postcss@8.4.49):
     dependencies:
       css-declaration-sorter: 6.4.1(postcss@8.4.49)
@@ -23989,39 +23926,6 @@ snapshots:
       postcss-reduce-transforms: 5.1.0(postcss@8.4.49)
       postcss-svgo: 5.1.0(postcss@8.4.49)
       postcss-unique-selectors: 5.1.1(postcss@8.4.49)
-
-  cssnano-preset-default@5.2.14(postcss@8.5.6):
-    dependencies:
-      css-declaration-sorter: 6.4.1(postcss@8.5.6)
-      cssnano-utils: 3.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-calc: 8.2.4(postcss@8.5.6)
-      postcss-colormin: 5.3.1(postcss@8.5.6)
-      postcss-convert-values: 5.1.3(postcss@8.5.6)
-      postcss-discard-comments: 5.1.2(postcss@8.5.6)
-      postcss-discard-duplicates: 5.1.0(postcss@8.5.6)
-      postcss-discard-empty: 5.1.1(postcss@8.5.6)
-      postcss-discard-overridden: 5.1.0(postcss@8.5.6)
-      postcss-merge-longhand: 5.1.7(postcss@8.5.6)
-      postcss-merge-rules: 5.1.4(postcss@8.5.6)
-      postcss-minify-font-values: 5.1.0(postcss@8.5.6)
-      postcss-minify-gradients: 5.1.1(postcss@8.5.6)
-      postcss-minify-params: 5.1.4(postcss@8.5.6)
-      postcss-minify-selectors: 5.2.1(postcss@8.5.6)
-      postcss-normalize-charset: 5.1.0(postcss@8.5.6)
-      postcss-normalize-display-values: 5.1.0(postcss@8.5.6)
-      postcss-normalize-positions: 5.1.1(postcss@8.5.6)
-      postcss-normalize-repeat-style: 5.1.1(postcss@8.5.6)
-      postcss-normalize-string: 5.1.0(postcss@8.5.6)
-      postcss-normalize-timing-functions: 5.1.0(postcss@8.5.6)
-      postcss-normalize-unicode: 5.1.1(postcss@8.5.6)
-      postcss-normalize-url: 5.1.0(postcss@8.5.6)
-      postcss-normalize-whitespace: 5.1.1(postcss@8.5.6)
-      postcss-ordered-values: 5.1.3(postcss@8.5.6)
-      postcss-reduce-initial: 5.1.2(postcss@8.5.6)
-      postcss-reduce-transforms: 5.1.0(postcss@8.5.6)
-      postcss-svgo: 5.1.0(postcss@8.5.6)
-      postcss-unique-selectors: 5.1.1(postcss@8.5.6)
 
   cssnano-preset-default@6.1.2(postcss@8.5.6):
     dependencies:
@@ -24091,59 +23995,70 @@ snapshots:
       postcss-svgo: 7.1.0(postcss@8.5.6)
       postcss-unique-selectors: 7.0.4(postcss@8.5.6)
 
-  cssnano-preset-default@7.0.6(postcss@8.5.6):
+  cssnano-preset-default@7.0.6(postcss@8.4.42):
     dependencies:
       browserslist: 4.24.4
-      css-declaration-sorter: 7.2.0(postcss@8.5.6)
-      cssnano-utils: 5.0.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-calc: 10.1.1(postcss@8.5.6)
-      postcss-colormin: 7.0.2(postcss@8.5.6)
-      postcss-convert-values: 7.0.4(postcss@8.5.6)
-      postcss-discard-comments: 7.0.3(postcss@8.5.6)
-      postcss-discard-duplicates: 7.0.1(postcss@8.5.6)
-      postcss-discard-empty: 7.0.0(postcss@8.5.6)
-      postcss-discard-overridden: 7.0.0(postcss@8.5.6)
-      postcss-merge-longhand: 7.0.4(postcss@8.5.6)
-      postcss-merge-rules: 7.0.4(postcss@8.5.6)
-      postcss-minify-font-values: 7.0.0(postcss@8.5.6)
-      postcss-minify-gradients: 7.0.0(postcss@8.5.6)
-      postcss-minify-params: 7.0.2(postcss@8.5.6)
-      postcss-minify-selectors: 7.0.4(postcss@8.5.6)
-      postcss-normalize-charset: 7.0.0(postcss@8.5.6)
-      postcss-normalize-display-values: 7.0.0(postcss@8.5.6)
-      postcss-normalize-positions: 7.0.0(postcss@8.5.6)
-      postcss-normalize-repeat-style: 7.0.0(postcss@8.5.6)
-      postcss-normalize-string: 7.0.0(postcss@8.5.6)
-      postcss-normalize-timing-functions: 7.0.0(postcss@8.5.6)
-      postcss-normalize-unicode: 7.0.2(postcss@8.5.6)
-      postcss-normalize-url: 7.0.0(postcss@8.5.6)
-      postcss-normalize-whitespace: 7.0.0(postcss@8.5.6)
-      postcss-ordered-values: 7.0.1(postcss@8.5.6)
-      postcss-reduce-initial: 7.0.2(postcss@8.5.6)
-      postcss-reduce-transforms: 7.0.0(postcss@8.5.6)
-      postcss-svgo: 7.0.1(postcss@8.5.6)
-      postcss-unique-selectors: 7.0.3(postcss@8.5.6)
+      css-declaration-sorter: 7.2.0(postcss@8.4.42)
+      cssnano-utils: 5.0.0(postcss@8.4.42)
+      postcss: 8.4.42
+      postcss-calc: 10.1.1(postcss@8.4.42)
+      postcss-colormin: 7.0.2(postcss@8.4.42)
+      postcss-convert-values: 7.0.4(postcss@8.4.42)
+      postcss-discard-comments: 7.0.3(postcss@8.4.42)
+      postcss-discard-duplicates: 7.0.1(postcss@8.4.42)
+      postcss-discard-empty: 7.0.0(postcss@8.4.42)
+      postcss-discard-overridden: 7.0.0(postcss@8.4.42)
+      postcss-merge-longhand: 7.0.4(postcss@8.4.42)
+      postcss-merge-rules: 7.0.4(postcss@8.4.42)
+      postcss-minify-font-values: 7.0.0(postcss@8.4.42)
+      postcss-minify-gradients: 7.0.0(postcss@8.4.42)
+      postcss-minify-params: 7.0.2(postcss@8.4.42)
+      postcss-minify-selectors: 7.0.4(postcss@8.4.42)
+      postcss-normalize-charset: 7.0.0(postcss@8.4.42)
+      postcss-normalize-display-values: 7.0.0(postcss@8.4.42)
+      postcss-normalize-positions: 7.0.0(postcss@8.4.42)
+      postcss-normalize-repeat-style: 7.0.0(postcss@8.4.42)
+      postcss-normalize-string: 7.0.0(postcss@8.4.42)
+      postcss-normalize-timing-functions: 7.0.0(postcss@8.4.42)
+      postcss-normalize-unicode: 7.0.2(postcss@8.4.42)
+      postcss-normalize-url: 7.0.0(postcss@8.4.42)
+      postcss-normalize-whitespace: 7.0.0(postcss@8.4.42)
+      postcss-ordered-values: 7.0.1(postcss@8.4.42)
+      postcss-reduce-initial: 7.0.2(postcss@8.4.42)
+      postcss-reduce-transforms: 7.0.0(postcss@8.4.42)
+      postcss-svgo: 7.0.1(postcss@8.4.42)
+      postcss-unique-selectors: 7.0.3(postcss@8.4.42)
+
+  cssnano-utils@3.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
 
   cssnano-utils@3.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
 
-  cssnano-utils@3.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-
   cssnano-utils@4.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  cssnano-utils@5.0.0(postcss@8.5.6):
+  cssnano-utils@5.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
+
+  cssnano-utils@5.0.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
 
   cssnano-utils@5.0.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+
+  cssnano@5.1.15(postcss@8.4.42):
+    dependencies:
+      cssnano-preset-default: 5.2.14(postcss@8.4.42)
+      lilconfig: 2.1.0
+      postcss: 8.4.42
+      yaml: 1.10.2
 
   cssnano@5.1.15(postcss@8.4.49):
     dependencies:
@@ -24152,24 +24067,17 @@ snapshots:
       postcss: 8.4.49
       yaml: 1.10.2
 
-  cssnano@5.1.15(postcss@8.5.6):
-    dependencies:
-      cssnano-preset-default: 5.2.14(postcss@8.5.6)
-      lilconfig: 2.1.0
-      postcss: 8.5.6
-      yaml: 1.10.2
-
   cssnano@6.1.2(postcss@8.5.6):
     dependencies:
       cssnano-preset-default: 6.1.2(postcss@8.5.6)
       lilconfig: 3.1.3
       postcss: 8.5.6
 
-  cssnano@7.0.6(postcss@8.5.6):
+  cssnano@7.0.6(postcss@8.4.42):
     dependencies:
-      cssnano-preset-default: 7.0.6(postcss@8.5.6)
+      cssnano-preset-default: 7.0.6(postcss@8.4.42)
       lilconfig: 3.1.3
-      postcss: 8.5.6
+      postcss: 8.4.42
 
   cssnano@7.1.2(postcss@8.5.6):
     dependencies:
@@ -26196,6 +26104,10 @@ snapshots:
       safer-buffer: 2.1.2
 
   icss-replace-symbols@1.1.0: {}
+
+  icss-utils@5.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
 
   icss-utils@5.1.0(postcss@8.4.49):
     dependencies:
@@ -28919,7 +28831,7 @@ snapshots:
     dependencies:
       npm-normalize-package-bin: 3.0.1
 
-  npm-check-updates@19.0.0: {}
+  npm-check-updates@22.2.9: {}
 
   npm-install-checks@6.3.0:
     dependencies:
@@ -29518,21 +29430,27 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
+  postcss-calc@10.1.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-selector-parser: 7.1.0
+      postcss-value-parser: 4.2.0
+
   postcss-calc@10.1.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
-  postcss-calc@8.2.4(postcss@8.4.49):
+  postcss-calc@8.2.4(postcss@8.4.42):
     dependencies:
-      postcss: 8.4.49
+      postcss: 8.4.42
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
-  postcss-calc@8.2.4(postcss@8.5.6):
+  postcss-calc@8.2.4(postcss@8.4.49):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.49
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
@@ -29568,20 +29486,20 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-colormin@5.3.1(postcss@8.4.42):
+    dependencies:
+      browserslist: 4.28.1
+      caniuse-api: 3.0.0
+      colord: 2.9.3
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-colormin@5.3.1(postcss@8.4.49):
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-colormin@5.3.1(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.28.1
-      caniuse-api: 3.0.0
-      colord: 2.9.3
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-colormin@6.1.0(postcss@8.5.6):
@@ -29592,12 +29510,12 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@7.0.2(postcss@8.5.6):
+  postcss-colormin@7.0.2(postcss@8.4.42):
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-colormin@7.0.5(postcss@8.5.6):
@@ -29608,16 +29526,16 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-convert-values@5.1.3(postcss@8.4.42):
+    dependencies:
+      browserslist: 4.28.1
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-convert-values@5.1.3(postcss@8.4.49):
     dependencies:
       browserslist: 4.28.1
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-convert-values@5.1.3(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.28.1
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@6.1.0(postcss@8.5.6):
@@ -29626,10 +29544,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@7.0.4(postcss@8.5.6):
+  postcss-convert-values@7.0.4(postcss@8.4.42):
     dependencies:
       browserslist: 4.28.1
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@7.0.8(postcss@8.5.6):
@@ -29668,21 +29586,21 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
+  postcss-discard-comments@5.1.2(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+
   postcss-discard-comments@5.1.2(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-
-  postcss-discard-comments@5.1.2(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
 
   postcss-discard-comments@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-comments@7.0.3(postcss@8.5.6):
+  postcss-discard-comments@7.0.3(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-selector-parser: 6.1.2
 
   postcss-discard-comments@7.0.5(postcss@8.5.6):
@@ -29690,61 +29608,61 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
+  postcss-discard-duplicates@5.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+
   postcss-discard-duplicates@5.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-
-  postcss-discard-duplicates@5.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
 
   postcss-discard-duplicates@6.0.3(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-duplicates@7.0.1(postcss@8.5.6):
+  postcss-discard-duplicates@7.0.1(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
 
   postcss-discard-duplicates@7.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
+  postcss-discard-empty@5.1.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+
   postcss-discard-empty@5.1.1(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-
-  postcss-discard-empty@5.1.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
 
   postcss-discard-empty@6.0.3(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-empty@7.0.0(postcss@8.5.6):
+  postcss-discard-empty@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
 
   postcss-discard-empty@7.0.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
+  postcss-discard-overridden@5.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+
   postcss-discard-overridden@5.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-
-  postcss-discard-overridden@5.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
 
   postcss-discard-overridden@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-overridden@7.0.0(postcss@8.5.6):
+  postcss-discard-overridden@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
 
   postcss-discard-overridden@7.0.1(postcss@8.5.6):
     dependencies:
@@ -29795,19 +29713,19 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.6)
       postcss: 8.5.6
 
+  postcss-load-config@3.1.4(postcss@8.4.42):
+    dependencies:
+      lilconfig: 2.1.0
+      yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.4.42
+
   postcss-load-config@3.1.4(postcss@8.4.49):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.4.49
-
-  postcss-load-config@3.1.4(postcss@8.5.6):
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 1.10.2
-    optionalDependencies:
-      postcss: 8.5.6
 
   postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.5.2)(webpack@5.105.0):
     dependencies:
@@ -29832,17 +29750,17 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-merge-longhand@5.1.7(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+      stylehacks: 5.1.1(postcss@8.4.42)
+
   postcss-merge-longhand@5.1.7(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
       postcss-value-parser: 4.2.0
       stylehacks: 5.1.1(postcss@8.4.49)
-
-  postcss-merge-longhand@5.1.7(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-      stylehacks: 5.1.1(postcss@8.5.6)
 
   postcss-merge-longhand@6.0.5(postcss@8.5.6):
     dependencies:
@@ -29850,11 +29768,11 @@ snapshots:
       postcss-value-parser: 4.2.0
       stylehacks: 6.1.1(postcss@8.5.6)
 
-  postcss-merge-longhand@7.0.4(postcss@8.5.6):
+  postcss-merge-longhand@7.0.4(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
-      stylehacks: 7.0.6(postcss@8.5.6)
+      stylehacks: 7.0.6(postcss@8.4.42)
 
   postcss-merge-longhand@7.0.5(postcss@8.5.6):
     dependencies:
@@ -29862,20 +29780,20 @@ snapshots:
       postcss-value-parser: 4.2.0
       stylehacks: 7.0.6(postcss@8.5.6)
 
+  postcss-merge-rules@5.1.4(postcss@8.4.42):
+    dependencies:
+      browserslist: 4.28.1
+      caniuse-api: 3.0.0
+      cssnano-utils: 3.1.0(postcss@8.4.42)
+      postcss: 8.4.42
+      postcss-selector-parser: 6.1.2
+
   postcss-merge-rules@5.1.4(postcss@8.4.49):
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
       cssnano-utils: 3.1.0(postcss@8.4.49)
       postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-
-  postcss-merge-rules@5.1.4(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.28.1
-      caniuse-api: 3.0.0
-      cssnano-utils: 3.1.0(postcss@8.5.6)
-      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   postcss-merge-rules@6.1.1(postcss@8.5.6):
@@ -29886,12 +29804,12 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-merge-rules@7.0.4(postcss@8.5.6):
+  postcss-merge-rules@7.0.4(postcss@8.4.42):
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.4.42)
+      postcss: 8.4.42
       postcss-selector-parser: 6.1.2
 
   postcss-merge-rules@7.0.7(postcss@8.5.6):
@@ -29902,14 +29820,14 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
+  postcss-minify-font-values@5.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-minify-font-values@5.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-minify-font-values@5.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-minify-font-values@6.1.0(postcss@8.5.6):
@@ -29917,14 +29835,21 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-minify-font-values@7.0.0(postcss@8.5.6):
+  postcss-minify-font-values@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-minify-font-values@7.0.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-gradients@5.1.1(postcss@8.4.42):
+    dependencies:
+      colord: 2.9.3
+      cssnano-utils: 3.1.0(postcss@8.4.42)
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@5.1.1(postcss@8.4.49):
@@ -29934,13 +29859,6 @@ snapshots:
       postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@5.1.1(postcss@8.5.6):
-    dependencies:
-      colord: 2.9.3
-      cssnano-utils: 3.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-
   postcss-minify-gradients@6.0.3(postcss@8.5.6):
     dependencies:
       colord: 2.9.3
@@ -29948,11 +29866,11 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@7.0.0(postcss@8.5.6):
+  postcss-minify-gradients@7.0.0(postcss@8.4.42):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.4.42)
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@7.0.1(postcss@8.5.6):
@@ -29962,18 +29880,18 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-minify-params@5.1.4(postcss@8.4.42):
+    dependencies:
+      browserslist: 4.28.1
+      cssnano-utils: 3.1.0(postcss@8.4.42)
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-minify-params@5.1.4(postcss@8.4.49):
     dependencies:
       browserslist: 4.28.1
       cssnano-utils: 3.1.0(postcss@8.4.49)
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-minify-params@5.1.4(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.28.1
-      cssnano-utils: 3.1.0(postcss@8.5.6)
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-minify-params@6.1.0(postcss@8.5.6):
@@ -29983,11 +29901,11 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@7.0.2(postcss@8.5.6):
+  postcss-minify-params@7.0.2(postcss@8.4.42):
     dependencies:
       browserslist: 4.28.1
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.4.42)
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-minify-params@7.0.5(postcss@8.5.6):
@@ -29997,14 +29915,14 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-minify-selectors@5.2.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-selector-parser: 6.1.2
+
   postcss-minify-selectors@5.2.1(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-
-  postcss-minify-selectors@5.2.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   postcss-minify-selectors@6.0.4(postcss@8.5.6):
@@ -30012,10 +29930,10 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-minify-selectors@7.0.4(postcss@8.5.6):
+  postcss-minify-selectors@7.0.4(postcss@8.4.42):
     dependencies:
       cssesc: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-selector-parser: 6.1.2
 
   postcss-minify-selectors@7.0.5(postcss@8.5.6):
@@ -30024,6 +29942,10 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
+  postcss-modules-extract-imports@3.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+
   postcss-modules-extract-imports@3.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
@@ -30031,6 +29953,13 @@ snapshots:
   postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+
+  postcss-modules-local-by-default@4.2.0(postcss@8.4.42):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.42)
+      postcss: 8.4.42
+      postcss-selector-parser: 7.1.0
+      postcss-value-parser: 4.2.0
 
   postcss-modules-local-by-default@4.2.0(postcss@8.4.49):
     dependencies:
@@ -30046,6 +29975,11 @@ snapshots:
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
+  postcss-modules-scope@3.2.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-selector-parser: 7.1.0
+
   postcss-modules-scope@3.2.1(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
@@ -30056,6 +29990,11 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
+  postcss-modules-values@4.0.0(postcss@8.4.42):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.42)
+      postcss: 8.4.42
+
   postcss-modules-values@4.0.0(postcss@8.4.49):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.49)
@@ -30065,6 +30004,18 @@ snapshots:
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
+
+  postcss-modules@4.3.1(postcss@8.4.42):
+    dependencies:
+      generic-names: 4.0.0
+      icss-replace-symbols: 1.1.0
+      lodash.camelcase: 4.3.0
+      postcss: 8.4.42
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.42)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.4.42)
+      postcss-modules-scope: 3.2.1(postcss@8.4.42)
+      postcss-modules-values: 4.0.0(postcss@8.4.42)
+      string-hash: 1.1.3
 
   postcss-modules@4.3.1(postcss@8.4.49):
     dependencies:
@@ -30078,18 +30029,6 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.4.49)
       string-hash: 1.1.3
 
-  postcss-modules@4.3.1(postcss@8.5.6):
-    dependencies:
-      generic-names: 4.0.0
-      icss-replace-symbols: 1.1.0
-      lodash.camelcase: 4.3.0
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
-      string-hash: 1.1.3
-
   postcss-nesting@13.0.2(postcss@8.5.6):
     dependencies:
       '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.0)
@@ -30097,34 +30036,34 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
+  postcss-normalize-charset@5.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+
   postcss-normalize-charset@5.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-
-  postcss-normalize-charset@5.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
 
   postcss-normalize-charset@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-normalize-charset@7.0.0(postcss@8.5.6):
+  postcss-normalize-charset@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
 
   postcss-normalize-charset@7.0.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
+  postcss-normalize-display-values@5.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-display-values@5.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-display-values@5.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-display-values@6.0.2(postcss@8.5.6):
@@ -30132,9 +30071,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-display-values@7.0.0(postcss@8.5.6):
+  postcss-normalize-display-values@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-normalize-display-values@7.0.1(postcss@8.5.6):
@@ -30142,14 +30081,14 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-positions@5.1.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-positions@5.1.1(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-positions@5.1.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@6.0.2(postcss@8.5.6):
@@ -30157,9 +30096,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@7.0.0(postcss@8.5.6):
+  postcss-normalize-positions@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@7.0.1(postcss@8.5.6):
@@ -30167,14 +30106,14 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-repeat-style@5.1.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-repeat-style@5.1.1(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-repeat-style@5.1.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-repeat-style@6.0.2(postcss@8.5.6):
@@ -30182,9 +30121,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@7.0.0(postcss@8.5.6):
+  postcss-normalize-repeat-style@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-normalize-repeat-style@7.0.1(postcss@8.5.6):
@@ -30192,14 +30131,14 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-string@5.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-string@5.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-string@5.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@6.0.2(postcss@8.5.6):
@@ -30207,9 +30146,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@7.0.0(postcss@8.5.6):
+  postcss-normalize-string@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@7.0.1(postcss@8.5.6):
@@ -30217,14 +30156,14 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-timing-functions@5.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-timing-functions@5.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-timing-functions@5.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-timing-functions@6.0.2(postcss@8.5.6):
@@ -30232,14 +30171,20 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@7.0.0(postcss@8.5.6):
+  postcss-normalize-timing-functions@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-normalize-timing-functions@7.0.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-unicode@5.1.1(postcss@8.4.42):
+    dependencies:
+      browserslist: 4.28.1
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@5.1.1(postcss@8.4.49):
@@ -30248,22 +30193,16 @@ snapshots:
       postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@5.1.1(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.28.1
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-
   postcss-normalize-unicode@6.1.0(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@7.0.2(postcss@8.5.6):
+  postcss-normalize-unicode@7.0.2(postcss@8.4.42):
     dependencies:
       browserslist: 4.28.1
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@7.0.5(postcss@8.5.6):
@@ -30272,16 +30211,16 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-url@5.1.0(postcss@8.4.42):
+    dependencies:
+      normalize-url: 6.1.0
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-url@5.1.0(postcss@8.4.49):
     dependencies:
       normalize-url: 6.1.0
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-url@5.1.0(postcss@8.5.6):
-    dependencies:
-      normalize-url: 6.1.0
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-url@6.0.2(postcss@8.5.6):
@@ -30289,9 +30228,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@7.0.0(postcss@8.5.6):
+  postcss-normalize-url@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-normalize-url@7.0.1(postcss@8.5.6):
@@ -30299,14 +30238,14 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-whitespace@5.1.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-whitespace@5.1.1(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-whitespace@5.1.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-whitespace@6.0.2(postcss@8.5.6):
@@ -30314,9 +30253,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@7.0.0(postcss@8.5.6):
+  postcss-normalize-whitespace@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-normalize-whitespace@7.0.1(postcss@8.5.6):
@@ -30328,16 +30267,16 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
+  postcss-ordered-values@5.1.3(postcss@8.4.42):
+    dependencies:
+      cssnano-utils: 3.1.0(postcss@8.4.42)
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-ordered-values@5.1.3(postcss@8.4.49):
     dependencies:
       cssnano-utils: 3.1.0(postcss@8.4.49)
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-ordered-values@5.1.3(postcss@8.5.6):
-    dependencies:
-      cssnano-utils: 3.1.0(postcss@8.5.6)
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-ordered-values@6.0.2(postcss@8.5.6):
@@ -30346,10 +30285,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@7.0.1(postcss@8.5.6):
+  postcss-ordered-values@7.0.1(postcss@8.4.42):
     dependencies:
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.4.42)
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-ordered-values@7.0.2(postcss@8.5.6):
@@ -30453,17 +30392,17 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-reduce-initial@5.1.2(postcss@8.4.42):
+    dependencies:
+      browserslist: 4.28.1
+      caniuse-api: 3.0.0
+      postcss: 8.4.42
+
   postcss-reduce-initial@5.1.2(postcss@8.4.49):
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
       postcss: 8.4.49
-
-  postcss-reduce-initial@5.1.2(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.28.1
-      caniuse-api: 3.0.0
-      postcss: 8.5.6
 
   postcss-reduce-initial@6.1.0(postcss@8.5.6):
     dependencies:
@@ -30471,11 +30410,11 @@ snapshots:
       caniuse-api: 3.0.0
       postcss: 8.5.6
 
-  postcss-reduce-initial@7.0.2(postcss@8.5.6):
+  postcss-reduce-initial@7.0.2(postcss@8.4.42):
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.4.42
 
   postcss-reduce-initial@7.0.5(postcss@8.5.6):
     dependencies:
@@ -30483,14 +30422,14 @@ snapshots:
       caniuse-api: 3.0.0
       postcss: 8.5.6
 
+  postcss-reduce-transforms@5.1.0(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-value-parser: 4.2.0
+
   postcss-reduce-transforms@5.1.0(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  postcss-reduce-transforms@5.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-reduce-transforms@6.0.2(postcss@8.5.6):
@@ -30498,9 +30437,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-transforms@7.0.0(postcss@8.5.6):
+  postcss-reduce-transforms@7.0.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
 
   postcss-reduce-transforms@7.0.1(postcss@8.5.6):
@@ -30546,15 +30485,15 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  postcss-svgo@5.1.0(postcss@8.4.49):
+  postcss-svgo@5.1.0(postcss@8.4.42):
     dependencies:
-      postcss: 8.4.49
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
 
-  postcss-svgo@5.1.0(postcss@8.5.6):
+  postcss-svgo@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
 
@@ -30564,9 +30503,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
-  postcss-svgo@7.0.1(postcss@8.5.6):
+  postcss-svgo@7.0.1(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
@@ -30576,14 +30515,14 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 4.0.0
 
+  postcss-unique-selectors@5.1.1(postcss@8.4.42):
+    dependencies:
+      postcss: 8.4.42
+      postcss-selector-parser: 6.1.2
+
   postcss-unique-selectors@5.1.1(postcss@8.4.49):
     dependencies:
       postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-
-  postcss-unique-selectors@5.1.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   postcss-unique-selectors@6.0.4(postcss@8.5.6):
@@ -30591,9 +30530,9 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-unique-selectors@7.0.3(postcss@8.5.6):
+  postcss-unique-selectors@7.0.3(postcss@8.4.42):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.4.42
       postcss-selector-parser: 6.1.2
 
   postcss-unique-selectors@7.0.4(postcss@8.5.6):
@@ -31443,6 +31382,25 @@ snapshots:
     dependencies:
       rollup: 4.28.0
 
+  rollup-plugin-postcss@4.0.2(postcss@8.4.42):
+    dependencies:
+      chalk: 4.1.2
+      concat-with-sourcemaps: 1.1.0
+      cssnano: 5.1.15(postcss@8.4.42)
+      import-cwd: 3.0.0
+      p-queue: 6.6.2
+      pify: 5.0.0
+      postcss: 8.4.42
+      postcss-load-config: 3.1.4(postcss@8.4.42)
+      postcss-modules: 4.3.1(postcss@8.4.42)
+      promise.series: 0.2.0
+      resolve: 1.22.10
+      rollup-pluginutils: 2.8.2
+      safe-identifier: 0.4.2
+      style-inject: 0.3.0
+    transitivePeerDependencies:
+      - ts-node
+
   rollup-plugin-postcss@4.0.2(postcss@8.4.49):
     dependencies:
       chalk: 4.1.2
@@ -31454,25 +31412,6 @@ snapshots:
       postcss: 8.4.49
       postcss-load-config: 3.1.4(postcss@8.4.49)
       postcss-modules: 4.3.1(postcss@8.4.49)
-      promise.series: 0.2.0
-      resolve: 1.22.10
-      rollup-pluginutils: 2.8.2
-      safe-identifier: 0.4.2
-      style-inject: 0.3.0
-    transitivePeerDependencies:
-      - ts-node
-
-  rollup-plugin-postcss@4.0.2(postcss@8.5.6):
-    dependencies:
-      chalk: 4.1.2
-      concat-with-sourcemaps: 1.1.0
-      cssnano: 5.1.15(postcss@8.5.6)
-      import-cwd: 3.0.0
-      p-queue: 6.6.2
-      pify: 5.0.0
-      postcss: 8.5.6
-      postcss-load-config: 3.1.4(postcss@8.5.6)
-      postcss-modules: 4.3.1(postcss@8.5.6)
       promise.series: 0.2.0
       resolve: 1.22.10
       rollup-pluginutils: 2.8.2
@@ -31789,14 +31728,14 @@ snapshots:
       sass-embedded: 1.81.0
       webpack: 5.105.0(esbuild@0.18.20)
 
-  sass-loader@16.0.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(sass-embedded@1.81.0)(sass@1.97.2)(webpack@5.105.0):
+  sass-loader@16.0.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(sass-embedded@1.81.0)(sass@1.97.2)(webpack@5.96.1):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       '@rspack/core': 1.6.6(@swc/helpers@0.5.17)
       sass: 1.97.2
       sass-embedded: 1.81.0
-      webpack: 5.105.0
+      webpack: 5.96.1(@swc/core@1.11.15(@swc/helpers@0.5.17))
 
   sass@1.97.2:
     dependencies:
@@ -32511,16 +32450,16 @@ snapshots:
       '@babel/core': 7.28.5
       babel-plugin-macros: 3.1.0
 
+  stylehacks@5.1.1(postcss@8.4.42):
+    dependencies:
+      browserslist: 4.28.1
+      postcss: 8.4.42
+      postcss-selector-parser: 6.1.2
+
   stylehacks@5.1.1(postcss@8.4.49):
     dependencies:
       browserslist: 4.28.1
       postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-
-  stylehacks@5.1.1(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.28.1
-      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   stylehacks@6.1.1(postcss@8.5.6):
@@ -32528,6 +32467,12 @@ snapshots:
       browserslist: 4.28.1
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
+
+  stylehacks@7.0.6(postcss@8.4.42):
+    dependencies:
+      browserslist: 4.28.1
+      postcss: 8.4.42
+      postcss-selector-parser: 7.1.0
 
   stylehacks@7.0.6(postcss@8.5.6):
     dependencies:


### PR DESCRIPTION
Since v21 there is ESM support; updated config accordingly.

Since v20 the cooldown is taken from pnpm config; removed cooldown from ncu config.
